### PR TITLE
feat: add MetricName and Namespace field in addtional_info and change title and rule field

### DIFF
--- a/src/spaceone/monitoring/manager/cloudwatch_event_manager.py
+++ b/src/spaceone/monitoring/manager/cloudwatch_event_manager.py
@@ -124,8 +124,8 @@ class EventManager(BaseManager):
             'severity': self._get_severity(message),
             'resource': self._get_resource_for_event(dimension, namespace, region),
             'description': message.get('NewStateReason', ''),
-            'title': self._remove_code_in_title(message.get('Subject', '')),
-            'rule': self._get_rule_for_event(message),
+            'title': message.get('AlarmName', ''),
+            'rule': message.get('AlarmName', ''),
             'occurred_at': occurred_at,
             'account': account_id,
             'additional_info': self._get_additional_info(message)
@@ -151,15 +151,6 @@ class EventManager(BaseManager):
             return datetime.now()
 
     @staticmethod
-    def _remove_code_in_title(title):
-        alert_codes = ['ALARM: ', 'OK: ', 'ALERT: ']
-        for alert_code in alert_codes:
-            if alert_code in title:
-                return title.replace(alert_code, '')
-
-        return title
-
-    @staticmethod
     def _get_event_key(message, resource_id, occurred_at):
         """
         Generate the Index Key through Hashing
@@ -175,12 +166,6 @@ class EventManager(BaseManager):
         md5_hash = hash_object.hexdigest()
 
         return md5_hash
-
-    @staticmethod
-    def _get_rule_for_event(message):
-        rule = ''
-
-        return rule
 
     @staticmethod
     def _get_resource_for_event_from_metric(dimension, event_resource, triggered_data, region):

--- a/src/spaceone/monitoring/model/cloudwatch_event_response_model.py
+++ b/src/spaceone/monitoring/model/cloudwatch_event_response_model.py
@@ -10,6 +10,8 @@ class CloudWatchAdditionalInfo(Model):
     AlarmName = StringType()
     OldStateValue = StringType()
     Region = StringType()
+    MetricName = StringType()
+    Namespace = StringType()
 
 
 class ResourceModel(Model):


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

Before and after comparison of two test cases.
All requirements of #1 are met.

### AS-IS
```python
{'results': [{'account': '123456789012',
              'additional_info': {'AWSAccountId': '123456789012',
                                  'AlarmArn': 'arn:aws:cloudwatch:ap-northeast-2:257706363616:alarm:ContainerInsight-pod_cpu_utilization',
                                  'AlarmName': 'ContainerInsight-pod_cpu_utilization',
                                  'OldStateValue': 'ALARM',
                                  'Region': 'Asia Pacific (Seoul)'},
              'description': 'Thresholds Crossed: 1 out of the last 1 '
                             'datapoints [0.46522264287069004 (27/06/21 '
                             '13:52:00)] was not less than the lower '
                             'thresholds [0.4129373661576242] or not greater '
                             'than the upper thresholds [0.4700330400585261] '
                             '(minimum 1 datapoint for ALARM -> OK '
                             'transition).',
              'event_key': '2a7ac6e9ea3c584f43c2698359fe4df6',
              'event_type': 'RECOVERY',
              'occurred_at': '2021-06-27T13:53:39.351Z',
              'provider': 'aws',
              'resource': {'name': '[ContainerInsights] '
                                   'ClusterName=cloudone-dev-v1-eks-cluster '
                                   '(Asia Pacific (Seoul))',
                           'resource_id': 'cloudone-dev-v1-eks-cluster',
                           'resource_type': 'ContainerInsights'},
              'severity': 'INFO'}]}


{'results': [{'account': '123456789012',
              'additional_info': {'AWSAccountId': '123456789012',
                                  'AlarmArn': 'arn:aws:cloudwatch:ap-northeast-2:123456789012:alarm:EC2-CPU',
                                  'AlarmName': 'EC2-CPU',
                                  'OldStateValue': 'INSUFFICIENT_DATA',
                                  'Region': 'Asia Pacific (Seoul)'},
              'description': 'Threshold Crossed: 1 out of the last 1 '
                             'datapoints [17.2564528039004 (23/06/21 '
                             '08:31:00)] was greater than the threshold (15.0) '
                             '(minimum 1 datapoint for OK -> ALARM '
                             'transition).',
              'event_key': '7633c875b916191f8b72054d0ee3dd17',
              'event_type': 'ALERT',
              'occurred_at': '2021-06-23T08:41:06.622Z',
              'provider': 'aws',
              'resource': {'name': '[AWS/EC2] InstanceId=i-0f672ea50a80cda4b '
                                   '(Asia Pacific (Seoul))',
                           'resource_id': 'i-0f672ea50a80cda4b',
                           'resource_type': 'AWS/EC2'},
              'severity': 'ERROR'}]}
```

### TO-BE
```python
{'results': [{'account': '123456789012',
              'additional_info': {'AWSAccountId': '123456789012',
                                  'AlarmArn': 'arn:aws:cloudwatch:ap-northeast-2:123456789012:alarm:ContainerInsight-pod_cpu_utilization',
                                  'AlarmName': 'ContainerInsight-pod_cpu_utilization',
                                  'MetricName': 'pod_cpu_utilization',
                                  'Namespace': 'ContainerInsights',
                                  'OldStateValue': 'ALARM',
                                  'Region': 'Asia Pacific (Seoul)'},
              'description': 'Thresholds Crossed: 1 out of the last 1 '
                             'datapoints [0.46522264287069004 (27/06/21 '
                             '13:52:00)] was not less than the lower '
                             'thresholds [0.4129373661576242] or not greater '
                             'than the upper thresholds [0.4700330400585261] '
                             '(minimum 1 datapoint for ALARM -> OK '
                             'transition).',
              'event_key': '2a7ac6e9ea3c584f43c2698359fe4df6',
              'event_type': 'RECOVERY',
              'occurred_at': '2021-06-27T13:53:39.351Z',
              'provider': 'aws',
              'resource': {'name': '[ContainerInsights] '
                                   'ClusterName=cloudone-dev-v1-eks-cluster '
                                   '(Asia Pacific (Seoul))',
                           'resource_id': 'cloudone-dev-v1-eks-cluster',
                           'resource_type': 'ContainerInsights'},
              'rule': 'ContainerInsight-pod_cpu_utilization',
              'severity': 'INFO',
              'title': 'ContainerInsight-pod_cpu_utilization'}]}


{'results': [{'account': '123456789012',
              'additional_info': {'AWSAccountId': '123456789012',
                                  'AlarmArn': 'arn:aws:cloudwatch:ap-northeast-2:257706363616:alarm:EC2-CPU',
                                  'AlarmName': 'EC2-CPU',
                                  'MetricName': 'CPUUtilization',
                                  'Namespace': 'AWS/EC2',
                                  'OldStateValue': 'INSUFFICIENT_DATA',
                                  'Region': 'Asia Pacific (Seoul)'},
              'description': 'Threshold Crossed: 1 out of the last 1 '
                             'datapoints [17.2564528039004 (23/06/21 '
                             '08:31:00)] was greater than the threshold (15.0) '
                             '(minimum 1 datapoint for OK -> ALARM '
                             'transition).',
              'event_key': '7633c875b916191f8b72054d0ee3dd17',
              'event_type': 'ALERT',
              'occurred_at': '2021-06-23T08:41:06.622Z',
              'provider': 'aws',
              'resource': {'name': '[AWS/EC2] InstanceId=i-0f672ea50a80cda4b '
                                   '(Asia Pacific (Seoul))',
                           'resource_id': 'i-0f672ea50a80cda4b',
                           'resource_type': 'AWS/EC2'},
              'rule': 'EC2-CPU',
              'severity': 'ERROR',
              'title': 'EC2-CPU'}]}
```